### PR TITLE
Standardise our spellchecking on CI

### DIFF
--- a/.codespell-ignore-words
+++ b/.codespell-ignore-words
@@ -1,4 +1,0 @@
-iam
-jupyter
-warmup
-colour

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -5,24 +5,21 @@ on:
     types: [opened, synchronize]
 
 jobs:
-  codespell:
-    name: Check spelling with codespell
+  spell-check:
+    name: spell-check
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        python-version: [3.8]
+    env:
+      ZENML_DEBUG: 1
+      ZENML_ANALYTICS_OPT_IN: false
     steps:
-      - uses: actions/checkout@v2
-      - name: Set up Python
-        uses: actions/setup-python@v2
-        with:
-          python-version: ${{ matrix.python-version }}
-      - name: Install dependencies
-        run: |
-          python -m pip install --upgrade pip
-          pip install codespell
-          if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
-      - name: Check spelling with codespell
-        run: codespell -c -I .codespell-ignore-words -f -i 0 --builtin clear,rare,en-GB_to_en-US,names,code . --skip="*.csv,*.sample" || exit 1
+    - name: Checkout Actions Repository
+      uses: actions/checkout@v2
+
+    - name: Spelling checker
+      uses: crate-ci/typos@master
+      with:
+        files: "."
+        config: ./.typos.toml
+
   markdown-link-check:
     uses: ./.github/workflows/markdown-link-check.yml

--- a/.typos.toml
+++ b/.typos.toml
@@ -1,5 +1,5 @@
 [files]
-# extend-exclude = ["*.json", "*.js", "*.ipynb", "src/zenml/zen_stores/migrations/versions/", "tests/unit/materializers/test_built_in_materializer.py", "tests/integration/functional/cli/test_pipeline.py"]
+extend-exclude = ["*.csv", "sign-language-detection-yolov5/*"]
 
 [default.extend-identifiers]
 #  HashiCorp = "HashiCorp"
@@ -7,6 +7,7 @@
 
 [default.extend-words]
 #  aks = "aks"
+GOES = "GOES"
 
 
 [default]

--- a/.typos.toml
+++ b/.typos.toml
@@ -1,0 +1,13 @@
+[files]
+# extend-exclude = ["*.json", "*.js", "*.ipynb", "src/zenml/zen_stores/migrations/versions/", "tests/unit/materializers/test_built_in_materializer.py", "tests/integration/functional/cli/test_pipeline.py"]
+
+[default.extend-identifiers]
+#  HashiCorp = "HashiCorp"
+
+
+[default.extend-words]
+#  aks = "aks"
+
+
+[default]
+locale = "en-us"

--- a/.typos.toml
+++ b/.typos.toml
@@ -1,5 +1,5 @@
 [files]
-extend-exclude = ["*.csv", "sign-language-detection-yolov5/*"]
+extend-exclude = ["*.csv", "sign-language-detection-yolov5/*", "orbit-user-analysis/steps/report.py", "customer-satisfaction/pipelines/deployment_pipeline.py", "customer-satisfaction/streamlit_app.py", "nba-pipeline/Building and Using An MLOPs Stack With ZenML.ipynb", "customer-satisfaction/tests/data_test.py"]
 
 [default.extend-identifiers]
 #  HashiCorp = "HashiCorp"

--- a/zen-news-summarization/README.md
+++ b/zen-news-summarization/README.md
@@ -153,7 +153,7 @@ Similar to the previous component, you just need to provide a name and the
 URI to your container registry on GCP.
 
 ```bash
-zenml container-registry register <CONTAINER_REGISTERY_NAME> \
+zenml container-registry register <CONTAINER_REGISTRY_NAME> \
     --flavor=gcp \
     --uri=<REGISTRY_URI>
 ```
@@ -203,7 +203,7 @@ version of our GCP stack.
 
 ```bash
 zenml stack register <STACK_NAME> \
-    -c <CONTAINER_REGISTERY_NAME> \
+    -c <CONTAINER_REGISTRY_NAME> \
     -a <ARTIFACT_STORE_NAME> \
     -o <ORCHESTRATOR_NAME> \
     --set


### PR DESCRIPTION
Switched out `codespelling` for `typos` so we have the same process on our main branches.