### PR TITLE
Add reranking functionality to retrieval process

### DIFF
--- a/llm-complete-guide/requirements.txt
+++ b/llm-complete-guide/requirements.txt
@@ -15,6 +15,7 @@ tiktoken
 umap-learn
 matplotlib
 pyarrow
+rerankers[all]
 
 # optional requirements for S3 artifact store
 # s3fs>2022.3.0


### PR DESCRIPTION
This pull request adds reranking functionality to the retrieval process in order to improve the relevance of the retrieved documents. It includes the following commits:

- add reranking to inference

- make reranking optional

The changes in the code include modifications to the `process_input_with_retrieval` function, which now includes a `rerank_documents` function to rerank the retrieved documents based on the input query. The reranked documents are then used in the completion process.