### PR TITLE
Fixes to the huggingface sagemaker example

### DIFF
--- a/huggingface-sagemaker/steps/promotion/promote_metric_compare_promoter.py
+++ b/huggingface-sagemaker/steps/promotion/promote_metric_compare_promoter.py
@@ -28,8 +28,8 @@ model_registry = Client().active_stack.model_registry
 
 @step
 def promote_metric_compare_promoter(
-    latest_metrics: Dict[str, str],
-    current_metrics: Dict[str, str],
+    latest_metrics: Dict[str, float],
+    current_metrics: Dict[str, float],
     metric_to_compare: str = "accuracy",
 ):
     """Try to promote trained model.

--- a/huggingface-sagemaker/steps/training/model_trainer.py
+++ b/huggingface-sagemaker/steps/training/model_trainer.py
@@ -154,6 +154,8 @@ def model_trainer(
     eval_results = trainer.evaluate(metric_key_prefix="")
 
     # Log the evaluation results in model control plane
-    log_artifact_metadata(output_name="model", metrics=eval_results)
+    log_artifact_metadata(
+        artifact_name="model", metadata={"metrics": eval_results}
+    )
 
     return model, tokenizer


### PR DESCRIPTION
I updated the huggingface sagemaker example to get to a working stage.
- fix artifact logging function
- log additional metadata about the sagemaker endpoint
- start with a small deployment instance so we don't incur costs accidentally and can keep it running for demos. the new type is 300 times cheaper than the one before.
- fix types in the promotion pipeline