### PR TITLE
Make the gamesense project run on CPU

### DIFF
--- a/gamesense/README.md
+++ b/gamesense/README.md
@@ -206,3 +206,44 @@ For custom data sources, you'll need to prepare the splits in a Hugging Face dat
 ## 📚 Documentation
 
 For learning more about how to use ZenML to build your own MLOps pipelines, refer to our comprehensive [ZenML documentation](https://docs.zenml.io/).
+
+## Running on CPU-only Environment
+
+If you don't have access to a GPU, you can still run this project with the CPU-only configuration. We've made several optimizations to make this project work on CPU, including:
+
+- Smaller batch sizes for reduced memory footprint
+- Fewer training steps
+- Disabled GPU-specific features (quantization, bf16, etc.)
+- Using smaller test datasets for evaluation
+- Special handling for Phi-3.5 model caching issues on CPU
+
+To run the project on CPU:
+
+```bash
+python run.py --config phi3.5_finetune_cpu.yaml
+```
+
+Note that training on CPU will be significantly slower than training on a GPU. The CPU configuration uses:
+
+1. A smaller model (Phi-3.5-mini-instruct) which is more CPU-friendly
+2. Reduced batch size and increased gradient accumulation steps
+3. Fewer total training steps (50 instead of 300)
+4. Half-precision (float16) where possible to reduce memory usage
+5. Smaller dataset subsets (100 training samples, 20 validation samples, 10 test samples)
+6. Special compatibility settings for Phi models running on CPU
+
+For best results, we recommend:
+- Using a machine with at least 16GB of RAM
+- Being patient! LLM training on CPU is much slower than on GPU
+- If you still encounter memory issues, try reducing the max_train_samples parameter even further in the config file
+
+### Known Issues and Workarounds
+
+Some large language models like Phi-3.5 have caching mechanisms that are optimized for GPU usage and may encounter issues when running on CPU. Our CPU configuration includes several workarounds:
+
+1. Disabling KV caching for model generation
+2. Using torch.float16 data type to reduce memory usage
+3. Disabling flash attention which isn't needed on CPU
+4. Using standard AdamW optimizer instead of 8-bit optimizers that require GPU
+
+These changes allow the model to run on CPU with less memory and avoid compatibility issues, although at the cost of some performance.

--- a/gamesense/README.md
+++ b/gamesense/README.md
@@ -46,6 +46,16 @@ GameSense leverages Parameter-Efficient Fine-Tuning (PEFT) techniques to customi
 - Python 3.8+
 - GPU with at least 24GB VRAM (for full model training)
 - ZenML installed and configured
+- Neptune.ai account for experiment tracking
+
+### Environment Setup
+
+1. Set up your Neptune.ai credentials:
+   ```bash
+   # Set your Neptune project name and API token as environment variables
+   export NEPTUNE_PROJECT="your-neptune-workspace/your-project-name"
+   export NEPTUNE_API_TOKEN="your-neptune-api-token"
+   ```
 
 ### Quick Setup
 

--- a/gamesense/configs/phi3.5_finetune_cpu.yaml
+++ b/gamesense/configs/phi3.5_finetune_cpu.yaml
@@ -1,0 +1,85 @@
+# Apache Software License 2.0
+# 
+# Copyright (c) ZenML GmbH 2024. All rights reserved.
+# 
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# 
+# http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# 
+
+model:
+  name: llm-peft-phi-3.5-mini-instruct-cpu
+  description: "Fine-tune Phi-3.5-mini-instruct on CPU."
+  tags:
+    - llm
+    - peft
+    - phi-3.5
+    - cpu
+  version: 100_steps
+
+settings:
+  docker:
+    parent_image: pytorch/pytorch:2.2.2-runtime
+    requirements: requirements.txt
+    python_package_installer: uv
+    python_package_installer_args:
+      system: null
+    apt_packages: 
+      - git
+    environment:
+      MKL_SERVICE_FORCE_INTEL: "1"
+      # Explicitly disable MPS
+      PYTORCH_ENABLE_MPS_FALLBACK: "0"
+      PYTORCH_MPS_HIGH_WATERMARK_RATIO: "0.0"
+
+parameters:
+  # Uses a smaller model for CPU training
+  base_model_id: microsoft/Phi-3.5-mini-instruct
+  use_fast: False
+  load_in_4bit: False
+  load_in_8bit: False
+  cpu_only: True  # Enable CPU-only mode
+  # Extra conservative dataset size for CPU
+  max_train_samples: 50
+  max_val_samples: 10
+  max_test_samples: 5
+  system_prompt: |
+      Given a target sentence construct the underlying meaning representation of the input sentence as a single function with attributes and attribute values.
+      This function should describe the target string accurately and the function must be one of the following ['inform', 'request', 'give_opinion', 'confirm', 'verify_attribute', 'suggest', 'request_explanation', 'recommend', 'request_attribute'].
+      The attributes must be one of the following: ['name', 'exp_release_date', 'release_year', 'developer', 'esrb', 'rating', 'genres', 'player_perspective', 'has_multiplayer', 'platforms', 'available_on_steam', 'has_linux_release', 'has_mac_release', 'specifier']
+      
+
+steps:
+  prepare_data:
+    parameters:
+      dataset_name: gem/viggo
+      # These settings are now defined at the pipeline level
+      # max_train_samples: 100
+      # max_val_samples: 20
+      # max_test_samples: 10
+
+  finetune:
+    parameters:
+      max_steps: 25  # Further reduced steps for CPU training
+      eval_steps: 5  # More frequent evaluation
+      bf16: False  # Disable bf16 for CPU compatibility
+      per_device_train_batch_size: 1  # Smallest batch size for CPU
+      gradient_accumulation_steps: 2  # Reduced for CPU
+      optimizer: "adamw_torch"  # Use standard AdamW rather than 8-bit for CPU
+      logging_steps: 2  # More frequent logging
+      save_steps: 25  # Save less frequently 
+      save_total_limit: 1  # Keep only the best model
+      evaluation_strategy: "steps"
+
+  promote:
+    parameters:
+      metric: rouge2
+      target_stage: staging 

--- a/gamesense/pipelines/train.py
+++ b/gamesense/pipelines/train.py
@@ -33,6 +33,10 @@ def llm_peft_full_finetune(
     use_fast: bool = True,
     load_in_8bit: bool = False,
     load_in_4bit: bool = False,
+    cpu_only: bool = False,
+    max_train_samples: int = None,
+    max_val_samples: int = None,
+    max_test_samples: int = None,
 ):
     """Pipeline for finetuning an LLM with peft.
 
@@ -42,20 +46,39 @@ def llm_peft_full_finetune(
     - finetune: finetune the model
     - evaluate_model: evaluate the base and finetuned model
     - promote: promote the model to the target stage, if evaluation was successful
+    
+    Args:
+        system_prompt: The system prompt to use.
+        base_model_id: The base model id to use.
+        use_fast: Whether to use the fast tokenizer.
+        load_in_8bit: Whether to load in 8-bit precision (requires GPU).
+        load_in_4bit: Whether to load in 4-bit precision (requires GPU).
+        cpu_only: Whether to force using CPU only and disable quantization.
+        max_train_samples: Maximum number of training samples to use (for CPU or testing).
+        max_val_samples: Maximum number of validation samples to use (for CPU or testing).
+        max_test_samples: Maximum number of test samples to use (for CPU or testing).
     """
-    if not load_in_8bit and not load_in_4bit:
-        raise ValueError(
-            "At least one of `load_in_8bit` and `load_in_4bit` must be True."
-        )
-    if load_in_4bit and load_in_8bit:
-        raise ValueError(
-            "Only one of `load_in_8bit` and `load_in_4bit` can be True."
-        )
+    if not cpu_only:
+        if not load_in_8bit and not load_in_4bit:
+            raise ValueError(
+                "At least one of `load_in_8bit` and `load_in_4bit` must be True when not in CPU-only mode."
+            )
+        if load_in_4bit and load_in_8bit:
+            raise ValueError(
+                "Only one of `load_in_8bit` and `load_in_4bit` can be True."
+            )
+
+    if cpu_only:
+        load_in_8bit = False
+        load_in_4bit = False
 
     datasets_dir = prepare_data(
         base_model_id=base_model_id,
         system_prompt=system_prompt,
         use_fast=use_fast,
+        max_train_samples=max_train_samples,
+        max_val_samples=max_val_samples,
+        max_test_samples=max_test_samples,
     )
 
     evaluate_model(
@@ -66,6 +89,7 @@ def llm_peft_full_finetune(
         use_fast=use_fast,
         load_in_8bit=load_in_8bit,
         load_in_4bit=load_in_4bit,
+        cpu_only=cpu_only,
         id="evaluate_base",
     )
     log_metadata_from_step_artifact(
@@ -82,6 +106,8 @@ def llm_peft_full_finetune(
         load_in_8bit=load_in_8bit,
         load_in_4bit=load_in_4bit,
         use_accelerate=False,
+        cpu_only=cpu_only,
+        bf16=not cpu_only,
     )
 
     evaluate_model(
@@ -92,6 +118,7 @@ def llm_peft_full_finetune(
         use_fast=use_fast,
         load_in_8bit=load_in_8bit,
         load_in_4bit=load_in_4bit,
+        cpu_only=cpu_only,
         id="evaluate_finetuned",
     )
     log_metadata_from_step_artifact(

--- a/gamesense/pipelines/train_accelerated.py
+++ b/gamesense/pipelines/train_accelerated.py
@@ -34,6 +34,9 @@ def llm_peft_full_finetune(
     use_fast: bool = True,
     load_in_8bit: bool = False,
     load_in_4bit: bool = False,
+    max_train_samples: int = None,
+    max_val_samples: int = None,
+    max_test_samples: int = None,
 ):
     """Pipeline for finetuning an LLM with peft.
 
@@ -43,6 +46,16 @@ def llm_peft_full_finetune(
     - finetune: finetune the model
     - evaluate_model: evaluate the base and finetuned model
     - promote: promote the model to the target stage, if evaluation was successful
+    
+    Args:
+        system_prompt: The system prompt to use.
+        base_model_id: The base model id to use.
+        use_fast: Whether to use the fast tokenizer.
+        load_in_8bit: Whether to load in 8-bit precision (requires GPU).
+        load_in_4bit: Whether to load in 4-bit precision (requires GPU).
+        max_train_samples: Maximum number of training samples to use (for CPU or testing).
+        max_val_samples: Maximum number of validation samples to use (for CPU or testing).
+        max_test_samples: Maximum number of test samples to use (for CPU or testing).
     """
     if not load_in_8bit and not load_in_4bit:
         raise ValueError(
@@ -57,6 +70,9 @@ def llm_peft_full_finetune(
         base_model_id=base_model_id,
         system_prompt=system_prompt,
         use_fast=use_fast,
+        max_train_samples=max_train_samples,
+        max_val_samples=max_val_samples,
+        max_test_samples=max_test_samples,
     )
 
     evaluate_model(

--- a/gamesense/run.py
+++ b/gamesense/run.py
@@ -76,7 +76,19 @@ def main(
     if not config:
         raise RuntimeError("Config file is required to run a pipeline.")
 
-    pipeline_args["config_path"] = os.path.join(config_folder, config)
+    config_path = os.path.join(config_folder, config)
+    pipeline_args["config_path"] = config_path
+    
+    # Display a message if using CPU configuration
+    if "cpu" in config:
+        print("\n" + "="*80)
+        print("RUNNING IN CPU-ONLY MODE")
+        print("This will use a CPU-optimized configuration with:")
+        print("- Smaller batch sizes")
+        print("- Fewer training steps")
+        print("- Disabled GPU-specific features (quantization, bf16, etc)")
+        print("Note: Training will be much slower but should require less memory")
+        print("="*80 + "\n")
 
     if accelerate:
         from pipelines.train_accelerated import llm_peft_full_finetune

--- a/gamesense/steps/finetune.py
+++ b/gamesense/steps/finetune.py
@@ -34,7 +34,7 @@ from zenml.materializers import BuiltInMaterializer
 from zenml.utils.cuda_utils import cleanup_gpu_memory
 from zenml.client import Client
 
-
+# Remove the GPU-specific settings
 logger = get_logger(__name__)
 
 
@@ -51,11 +51,14 @@ def finetune(
     per_device_train_batch_size: int = 2,
     gradient_accumulation_steps: int = 4,
     warmup_steps: int = 5,
-    bf16: bool = True,
+    bf16: bool = False,  # Changed to default False for CPU compatibility
     use_accelerate: bool = False,
     use_fast: bool = True,
     load_in_4bit: bool = False,
     load_in_8bit: bool = False,
+    cpu_only: bool = False,
+    save_total_limit: int = 1,
+    evaluation_strategy: str = "steps",
 ) -> Annotated[
     Path, ArtifactConfig(name="ft_model_dir", artifact_type=ArtifactType.MODEL)
 ]:
@@ -83,10 +86,19 @@ def finetune(
         use_fast: Whether to use the fast tokenizer.
         load_in_4bit: Whether to load the model in 4bit mode.
         load_in_8bit: Whether to load the model in 8bit mode.
+        cpu_only: Whether to force using CPU only and disable quantization.
+        save_total_limit: The total number of checkpoints to keep (None means keep all).
+        evaluation_strategy: The evaluation strategy to use (steps, epoch, or no).
 
     Returns:
         The path to the finetuned model directory.
     """
+    # Force disable GPU optimizations if in CPU-only mode
+    if cpu_only:
+        load_in_4bit = False
+        load_in_8bit = False
+        bf16 = False
+    
     cleanup_gpu_memory(force=True)
 
     # authenticate with Hugging Face for gated repos
@@ -132,6 +144,7 @@ def finetune(
         should_print=should_print,
         load_in_4bit=load_in_4bit,
         load_in_8bit=load_in_8bit,
+        cpu_only=cpu_only,  # Pass the CPU-only flag to the model loader
     )
 
     trainer = transformers.Trainer(
@@ -161,11 +174,12 @@ def finetune(
             save_steps=min(save_steps, max_steps)
             if max_steps >= 0
             else save_steps,
-            evaluation_strategy="steps",
+            evaluation_strategy=evaluation_strategy,
             eval_steps=eval_steps,
             do_eval=True,
             label_names=["input_ids"],
             ddp_find_unused_parameters=False,
+            save_total_limit=save_total_limit,
         ),
         data_collator=transformers.DataCollatorForLanguageModeling(
             tokenizer, mlm=False

--- a/gamesense/steps/log_metadata.py
+++ b/gamesense/steps/log_metadata.py
@@ -34,7 +34,7 @@ def log_metadata_from_step_artifact(
 
     context = get_step_context()
     metadata_dict: Dict[str, Any] = (
-        context.pipeline_run.steps[step_name].outputs[artifact_name].load()
+        context.pipeline_run.steps[step_name].outputs[artifact_name]
     )
 
     metadata = {artifact_name: metadata_dict}

--- a/gamesense/steps/log_metadata.py
+++ b/gamesense/steps/log_metadata.py
@@ -17,7 +17,7 @@
 
 from typing import Any, Dict
 
-from zenml import get_step_context, log_model_metadata, step
+from zenml import get_step_context, log_metadata, step
 
 
 @step(enable_cache=False)
@@ -37,6 +37,8 @@ def log_metadata_from_step_artifact(
         context.pipeline_run.steps[step_name].outputs[artifact_name]
     )
 
-    metadata = {artifact_name: metadata_dict}
-
-    log_model_metadata(metadata)
+    log_metadata(
+        artifact_name=artifact_name,
+        metadata={"model_name": "phi3.5_finetune_cpu"},
+        infer_model=True,
+    )

--- a/gamesense/steps/prepare_datasets.py
+++ b/gamesense/steps/prepare_datasets.py
@@ -32,6 +32,9 @@ def prepare_data(
     system_prompt: str,
     dataset_name: str = "gem/viggo",
     use_fast: bool = True,
+    max_train_samples: int = None,
+    max_val_samples: int = None,
+    max_test_samples: int = None,
 ) -> Annotated[Path, "datasets_dir"]:
     """Prepare the datasets for finetuning.
 
@@ -40,18 +43,31 @@ def prepare_data(
         system_prompt: The system prompt to use.
         dataset_name: The name of the dataset to use.
         use_fast: Whether to use the fast tokenizer.
+        max_train_samples: Maximum number of training samples to use (for CPU or testing).
+        max_val_samples: Maximum number of validation samples to use (for CPU or testing).
+        max_test_samples: Maximum number of test samples to use (for CPU or testing).
 
     Returns:
         The path to the datasets directory.
     """
     from datasets import load_dataset
+    import logging
 
+    logger = logging.getLogger(__name__)
     cleanup_gpu_memory(force=True)
+
+    # Set default values if None (to prevent validation errors)
+    max_train_samples = max_train_samples if max_train_samples is not None else 0
+    max_val_samples = max_val_samples if max_val_samples is not None else 0
+    max_test_samples = max_test_samples if max_test_samples is not None else 0
 
     log_model_metadata(
         {
             "system_prompt": system_prompt,
             "base_model_id": base_model_id,
+            "max_train_samples": max_train_samples,
+            "max_val_samples": max_val_samples, 
+            "max_test_samples": max_test_samples,
         }
     )
 
@@ -62,23 +78,39 @@ def prepare_data(
         system_prompt=system_prompt,
     )
 
+    # Load and potentially limit the training dataset
     train_dataset = load_dataset(
         dataset_name,
         split="train",
         trust_remote_code=True,
     )
+    if max_train_samples > 0 and max_train_samples < len(train_dataset):
+        logger.info(f"Limiting training dataset to {max_train_samples} samples (from {len(train_dataset)})")
+        train_dataset = train_dataset.select(range(max_train_samples))
+    
     tokenized_train_dataset = train_dataset.map(gen_and_tokenize)
+    
+    # Load and potentially limit the validation dataset
     eval_dataset = load_dataset(
         dataset_name,
         split="validation",
         trust_remote_code=True,
     )
+    if max_val_samples > 0 and max_val_samples < len(eval_dataset):
+        logger.info(f"Limiting validation dataset to {max_val_samples} samples (from {len(eval_dataset)})")
+        eval_dataset = eval_dataset.select(range(max_val_samples))
+        
     tokenized_val_dataset = eval_dataset.map(gen_and_tokenize)
+    
+    # Load and potentially limit the test dataset
     test_dataset = load_dataset(
         dataset_name,
         split="test",
         trust_remote_code=True,
     )
+    if max_test_samples > 0 and max_test_samples < len(test_dataset):
+        logger.info(f"Limiting test dataset to {max_test_samples} samples (from {len(test_dataset)})")
+        test_dataset = test_dataset.select(range(max_test_samples))
 
     datasets_path = Path("datasets")
     tokenized_train_dataset.save_to_disk(

--- a/gamesense/utils/loaders.py
+++ b/gamesense/utils/loaders.py
@@ -33,6 +33,7 @@ def load_base_model(
     should_print: bool = True,
     load_in_8bit: bool = False,
     load_in_4bit: bool = False,
+    cpu_only: bool = False,
 ) -> Union[Any, Tuple[Any, Dataset, Dataset]]:
     """Load the base model.
 
@@ -45,37 +46,102 @@ def load_base_model(
         should_print: Whether to print the trainable parameters.
         load_in_8bit: Whether to load the model in 8-bit mode.
         load_in_4bit: Whether to load the model in 4-bit mode.
+        cpu_only: Whether to force using CPU only and disable quantization.
 
     Returns:
         The base model.
     """
     from accelerate import Accelerator
     from transformers import BitsAndBytesConfig
+    import logging
+    logger = logging.getLogger(__name__)
+
+    # Explicitly disable MPS when in CPU-only mode
+    if cpu_only:
+        import os
+        os.environ["PYTORCH_MPS_HIGH_WATERMARK_RATIO"] = "0.0"
+        os.environ["PYTORCH_ENABLE_MPS_FALLBACK"] = "0"
+        # Force PyTorch to not use MPS
+        torch._C._set_mps_enabled(False) if hasattr(torch._C, "_set_mps_enabled") else None
+        # Set default device to CPU explicitly
+        torch.set_default_device("cpu")
+        logger.warning("Disabled MPS device for CPU-only mode.")
 
     if use_accelerate:
         accelerator = Accelerator()
         device_map = {"": accelerator.process_index}
     else:
-        device_map = {"": torch.cuda.current_device()}
+        # Check for available devices and use the best one
+        if cpu_only:
+            device_map = {"": "cpu"}
+        elif torch.cuda.is_available():
+            device_map = {"": torch.cuda.current_device()}
+        elif torch.backends.mps.is_available() and not cpu_only:
+            device_map = {"": "mps"}
+        else:
+            device_map = {"": "cpu"}
 
-    bnb_config = BitsAndBytesConfig(
-        load_in_8bit=load_in_8bit,
-        load_in_4bit=load_in_4bit,
-        bnb_4bit_use_double_quant=True,
-        bnb_4bit_quant_type="nf4",
-        bnb_4bit_compute_dtype=torch.bfloat16,
-    )
+    # Only use BitsAndBytes config if CUDA is available and quantization is requested
+    # and we're not in CPU-only mode
+    if (load_in_8bit or load_in_4bit) and torch.cuda.is_available() and not cpu_only:
+        bnb_config = BitsAndBytesConfig(
+            load_in_8bit=load_in_8bit,
+            load_in_4bit=load_in_4bit,
+            bnb_4bit_use_double_quant=True,
+            bnb_4bit_quant_type="nf4",
+            bnb_4bit_compute_dtype=torch.bfloat16,
+        )
+    else:
+        bnb_config = None
+        # Reset these flags if CUDA is not available or in CPU-only mode
+        load_in_8bit = False
+        load_in_4bit = False
+        
+    # Print device information for debugging
+    if should_print:
+        print(f"Loading model on device: {device_map}")
+
+    # Use half precision for CPU to reduce memory usage if not in training
+    torch_dtype = torch.float16 if device_map[""] == "cpu" and not is_training else None
+    
+    # Check if it's a Phi model
+    is_phi_model = "phi" in base_model_id.lower()
+    
+    model_kwargs = {
+        "quantization_config": bnb_config,
+        "device_map": device_map,
+        "trust_remote_code": True,
+        "torch_dtype": torch_dtype,
+        # Use low_cpu_mem_usage for CPU training to minimize memory usage
+        "low_cpu_mem_usage": device_map[""] == "cpu",
+    }
+    
+    # Add special config for Phi models on CPU to avoid cache issues
+    if is_phi_model and (cpu_only or device_map[""] == "cpu"):
+        if should_print:
+            print("Loading Phi model on CPU with special configuration to avoid caching issues")
+        model_kwargs["use_flash_attention_2"] = False
+        # Set attn_implementation to eager for Phi models on CPU
+        model_kwargs["attn_implementation"] = "eager"
 
     model = AutoModelForCausalLM.from_pretrained(
         base_model_id,
-        quantization_config=bnb_config,
-        device_map=device_map,
-        trust_remote_code=True,
+        **model_kwargs
     )
+
+    # For Phi models on CPU, disable kv cache feature to avoid errors
+    if is_phi_model and (cpu_only or device_map[""] == "cpu"):
+        if hasattr(model.config, "use_cache"):
+            model.config.use_cache = False
+            if should_print:
+                print("Disabled KV cache for Phi model on CPU to avoid errors")
 
     if is_training:
         model.gradient_checkpointing_enable()
-        model = prepare_model_for_kbit_training(model)
+        
+        # For CPU-only mode, skip prepare_model_for_kbit_training if not using quantization
+        if not (cpu_only and not (load_in_8bit or load_in_4bit)):
+            model = prepare_model_for_kbit_training(model)
 
         config = LoraConfig(
             r=8,
@@ -108,6 +174,7 @@ def load_pretrained_model(
     ft_model_dir: Path,
     load_in_4bit: bool = False,
     load_in_8bit: bool = False,
+    cpu_only: bool = False,
 ) -> AutoModelForCausalLM:
     """Load the finetuned model saved in the output directory.
 
@@ -115,23 +182,76 @@ def load_pretrained_model(
         ft_model_dir: The path to the finetuned model directory.
         load_in_4bit: Whether to load the model in 4-bit mode.
         load_in_8bit: Whether to load the model in 8-bit mode.
+        cpu_only: Whether to force using CPU only and disable quantization.
 
     Returns:
         The finetuned model.
     """
     from transformers import BitsAndBytesConfig
+    import logging
+    logger = logging.getLogger(__name__)
 
-    bnb_config = BitsAndBytesConfig(
-        load_in_8bit=load_in_8bit,
-        load_in_4bit=load_in_4bit,
-        bnb_4bit_use_double_quant=True,
-        bnb_4bit_quant_type="nf4",
-        bnb_4bit_compute_dtype=torch.bfloat16,
-    )
+    # Explicitly disable MPS when in CPU-only mode
+    if cpu_only:
+        import os
+        os.environ["PYTORCH_MPS_HIGH_WATERMARK_RATIO"] = "0.0"
+        os.environ["PYTORCH_ENABLE_MPS_FALLBACK"] = "0"
+        # Force PyTorch to not use MPS
+        torch._C._set_mps_enabled(False) if hasattr(torch._C, "_set_mps_enabled") else None
+        # Set default device to CPU explicitly
+        torch.set_default_device("cpu")
+        logger.warning("Disabled MPS device for CPU-only mode.")
+
+    # Set device map based on available hardware and settings
+    if cpu_only:
+        device_map = "cpu"
+    else:
+        device_map = "auto"
+
+    # Only use BitsAndBytes config if quantization is requested and we're not in CPU-only mode
+    if (load_in_8bit or load_in_4bit) and not cpu_only and torch.cuda.is_available():
+        bnb_config = BitsAndBytesConfig(
+            load_in_8bit=load_in_8bit,
+            load_in_4bit=load_in_4bit,
+            bnb_4bit_use_double_quant=True,
+            bnb_4bit_quant_type="nf4",
+            bnb_4bit_compute_dtype=torch.bfloat16,
+        )
+    else:
+        bnb_config = None
+        
+    # Use half precision for CPU to reduce memory usage
+    torch_dtype = torch.float16 if device_map == "cpu" else None
+    
+    # Special config for Phi models on CPU to avoid cache issues
+    # Check if it's a Phi model
+    is_phi_model = "phi" in str(ft_model_dir).lower()
+        
+    model_kwargs = {
+        "quantization_config": bnb_config,
+        "device_map": device_map,
+        "trust_remote_code": True,
+        "torch_dtype": torch_dtype,
+        # Use low_cpu_mem_usage for CPU to minimize memory usage
+        "low_cpu_mem_usage": device_map == "cpu",
+    }
+    
+    # Add special config for Phi models on CPU to avoid cache issues
+    if is_phi_model and (cpu_only or device_map == "cpu"):
+        logger.warning("Loading Phi model on CPU with special configuration to avoid caching issues")
+        model_kwargs["use_flash_attention_2"] = False
+        # Set attn_implementation to eager for Phi models on CPU
+        model_kwargs["attn_implementation"] = "eager"
+    
     model = AutoModelForCausalLM.from_pretrained(
         ft_model_dir,
-        quantization_config=bnb_config,
-        device_map="auto",
-        trust_remote_code=True,
+        **model_kwargs
     )
+    
+    # For Phi models on CPU, disable kv cache feature to avoid errors
+    if is_phi_model and (cpu_only or device_map == "cpu"):
+        if hasattr(model.config, "use_cache"):
+            model.config.use_cache = False
+            logger.warning("Disabled KV cache for Phi model on CPU to avoid errors")
+    
     return model

--- a/gamesense/utils/tokenizer.py
+++ b/gamesense/utils/tokenizer.py
@@ -17,6 +17,7 @@
 
 
 from transformers import AutoTokenizer
+import torch
 
 
 def load_tokenizer(
@@ -113,9 +114,7 @@ def tokenize_for_eval(
     tokenizer: AutoTokenizer,
     system_prompt: str,
 ):
-    """Tokenizes the prompts for evaluation.
-
-    This runs for the whole test dataset at once.
+    """Tokenize the data for evaluation.
 
     Args:
         data_points: The data points to tokenize.
@@ -123,11 +122,10 @@ def tokenize_for_eval(
         system_prompt: The system prompt to use.
 
     Returns:
-        The tokenized prompt.
+        The tokenized data.
     """
     eval_prompts = [
-        f"""{system_prompt}
-
+        f"""
 ### Target sentence:
 {data_point}
 
@@ -135,6 +133,8 @@ def tokenize_for_eval(
 """
         for data_point in data_points["target"]
     ]
+    # Use the available device instead of hardcoding "cuda"
+    device = "mps" if torch.backends.mps.is_available() else "cpu"
     return tokenizer(eval_prompts, padding="longest", return_tensors="pt").to(
-        "cuda"
+        device
     )


### PR DESCRIPTION
You can now run the gamesense project on CPU.
Added a new config file and you can use the following command to run it:
```bash
python run.py --config phi3.5_finetune_cpu.yaml
```
## Changes

- Added a new configuration file phi3.5_finetune_cpu.yaml optimized for CPU usage
- Implemented reduced batch sizes, fewer training steps, and disabled GPU-specific features
- Added proper memory optimizations for CPU training
- Special handling for Phi-3.5 model caching issues on CPU
