### PR TITLE
Fix "no match for platform" GH action failure

### DIFF
--- a/.github/workflows/build-push-codespace.yml
+++ b/.github/workflows/build-push-codespace.yml
@@ -153,6 +153,8 @@ jobs:
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
+        with:
+          platforms: linux/amd64
 
       - name: Login to DockerHub
         uses: docker/login-action@v2
@@ -166,6 +168,7 @@ jobs:
           context: .
           file: ${{ matrix.project }}/Dockerfile.codespace
           push: true
+          platforms: linux/amd64
           tags: zenmldocker/projects-${{ matrix.project }}:${{ steps.timestamp.outputs.timestamp }}
           cache-from: type=gha
           cache-to: type=gha,mode=max


### PR DESCRIPTION
Force Docker to use the amd64 variant in our GitHub Actions workflow to fix the `no match for platform in manifest` error when pulling `zenml-sandbox:latest`.