### PR TITLE
chore: update README.md of zenml-support-agent to correct installation path

### DIFF
--- a/zenml-support-agent/README.md
+++ b/zenml-support-agent/README.md
@@ -108,7 +108,7 @@ Install the required packages via the `requirements.txt` file located in the
 `/src` directory.
 
 ```bash
-pip install -r src/requirements.txt
+pip install -r requirements.txt
 ```
 
 You will also need to set your `OPENAI_API_KEY` as an environment variable wherever you plan to run the pipeline.


### PR DESCRIPTION
**Problem**
Running the installation command from  `zenml-support-agent` fails.

```
$ pip install -r src/requirements.txt
Defaulting to user installation because normal site-packages is not writeable
ERROR: Could not open requirements file: [Errno 2] No such file or directory: 'src/requirements.txt'
```

This is because requirements is in the root directory and there is no `src` subdirectory.

**Solution**
Remove `src/` from the path.

**Alternative**
Create `src` directory, but I chose not to because all other directories except 1 have this file structure.