### PR TITLE
Fix README mismatches

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,16 +63,16 @@ etc.
 | [Gamesense](gamesense)                                    | 🤖 LLMOps | 🧠 LoRA, ⚡ Efficient Training             | pytorch, peft, phi-2                 |
 | [Nightwatch AI](nightwatch-ai)                            | 🤖 LLMOps | 📝 Summarization, 📊 Reporting             | openai, supabase, slack              |
 | [ResearchRadar](research-radar)                           | 🤖 LLMOps | 📝 Classification, 📊 Comparison           | anthropic, huggingface, transformers |
-| [End-to-end Computer Vision](end-to-end-computer-vision)  | 👁️ Vision | 🎯 Object Detection, 🏷️ Labeling           | pytorch, label_studio, yolov8        |
-| [Magic Photobooth](magic-photobooth)                      | 👁️ Vision | 🖼️ Image Gen, 🎬 Video Gen                 | stable-diffusion, huggingface        |
-| [OmniReader](omni-reader)                                 | 👁️ Vision | 📝 OCR, 📊 Evaluation, 🔄 Batch Processing | polars, litellm, openai, ollama      |
+| [End-to-end Computer Vision](end-to-end-computer-vision)  | 👁 Computer Vision | 🔎 Object Detection, 🏷️ Labeling           | pytorch, label_studio, yolov8 |
+| [Magic Photobooth](magic-photobooth)                      | 👁 Computer Vision | 📷 Image Gen, 🎞️ Video Gen                 | stable-diffusion, huggingface |
+| [OmniReader](omni-reader)                                 | 👁 Computer Vision | 📑 OCR, 📊 Evaluation, ⚙️ Batch Processing | polars, litellm, openai, ollama |
 | [Oncoclear](oncoclear)                                    | 🚀 MLOps  | 📦 Deployment, 🔄 CI/CD                    | docker, kubernetes, scikit-learn     |
-| [Sign Language Detection](sign-language-detection-yolov5) | 👁️ Vision | 🎯 Object Detection, ⚡ Real-time          | mlflow, bentoml, vertex-ai           |
+| [Sign Language Detection](sign-language-detection-yolov5) | 👁 Computer Vision | 🔎 Object Detection, ⚡ Real-time          | mlflow, bentoml, vertex-ai |
 | [Huggingface to Sagemaker](huggingface-sagemaker)         | 🚀 MLOps  | 🔄 CI/CD, 📦 Deployment                    | mlflow, sagemaker, kubeflow          |
 | [Databricks Production QA](databricks-production-qa-demo) | 🚀 MLOps  | 📊 Monitoring, 🔍 Quality Assurance        | databricks, evidently, shap          |
-| [Eurorate Predictor](eurorate-predictor)                  | 📊 Data   | ⏱️ Time Series, 🔄 ETL                     | airflow, bigquery, xgboost           |
-| [RetailForecast](retail-forecast)                         | 📊 Data   | ⏱️ Time Series, 📈 Forecasting, 🔮 Multi-Model | prophet, zenml, pandas                |
-| [Bank Subscription Prediction](bank_subscription_prediction) | 📊 Data | 💼 Classification, ⚖️ Imbalanced Data, 🎯 Feature Selection | xgboost, plotly, zenml |
+| [Eurorate Predictor](eurorate-predictor)                  | 📊 Data   | ⏱️ Time Series, 🧹 ETL                     | airflow, bigquery, xgboost |
+| [RetailForecast](retail-forecast)                         | 📊 Data   | ⏱️ Time Series, 📈 Forecasting, 🔄 Multi-Model | prophet, zenml, pandas |
+| [Bank Subscription Prediction](bank_subscription_prediction) | 📊 Data | 💼 Classification, ⚖️ Imbalanced Data, 🔍 Feature Selection | xgboost, plotly, zenml |
 
 # 💻 System Requirements
 

--- a/huggingface-sagemaker/README.md
+++ b/huggingface-sagemaker/README.md
@@ -98,7 +98,7 @@ To run this project, you need to create a [ZenML Stack](https://docs.zenml.io/us
 ```shell
 make install-stack
 
-zenml stack hf-sagekamer-local
+zenml stack set hf-sagemaker-local
 ```
 
 Additionally, if you're using the local Docker orchestrator, you'll need to create a cache directory for the datasets and ensure it has the correct permissions:

--- a/magic-photobooth/README.md
+++ b/magic-photobooth/README.md
@@ -49,7 +49,7 @@ Behind the scenes, Magic Photobooth employs Low-Rank Adaptation (LoRA) technolog
    git clone https://github.com/zenml-io/zenml-projects.git
    
    # Navigate to Magic Photobooth
-   cd zenml-projects/flux-dreambooth
+    cd zenml-projects/magic-photobooth
    
    # Install dependencies
    pip install -r requirements.txt

--- a/sign-language-detection-yolov5/README.md
+++ b/sign-language-detection-yolov5/README.md
@@ -56,7 +56,6 @@ git clone https://github.com/zenml-io/zenml-projects.git
 git submodule update --init --recursive
 cd zenml-projects/sign-language-detection-yolov5
 pip install -r requirements.txt
-pip install -r yolov5/requirements.txt
 ```
 
 Starting with ZenML 0.20.0, ZenML comes bundled with a React-based dashboard. This dashboard allows you to observe your stacks, stack components and pipeline DAGs in a dashboard interface. To access this, you need to  [launch the ZenML Server and Dashboard locally](https://docs.zenml.io/user-guides/starter-guide#explore-the-dashboard), but first you must install the optional dependencies for the ZenML server:


### PR DESCRIPTION
## Summary
- fix stack command typo in huggingface-sagemaker README
- correct project folder name in magic-photobooth README
- drop non-existent yolov5 requirements from sign language project
- update project table descriptions in root README

## Testing
- `ruff check .` *(fails: unrecognized subcommand or lint issues)*